### PR TITLE
Fixed zeroTozero cases

### DIFF
--- a/build/storage_sm_rom.json
+++ b/build/storage_sm_rom.json
@@ -2988,7 +2988,27 @@
    },
    "inFREE": "1",
    "setRKEY": 1,
-   "line": 12,
+   "line": 22,
+   "fileName": "storage_sm_set_zero_to_zero.zkasm"
+  },
+  {
+   "freeInTag": {
+    "op": "functionCall",
+    "funcName": "GetIsOld0",
+    "params": []
+   },
+   "inFREE": "1",
+   "iJmpz": "1",
+   "addressLabel": "SZTZ_IsLeafNode",
+   "line": 24,
+   "address": 355,
+   "fileName": "storage_sm_set_zero_to_zero.zkasm"
+  },
+  {
+   "iJmp": "1",
+   "addressLabel": "SZTZ_IsIntermediateNode",
+   "line": 25,
+   "address": 361,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
@@ -2998,9 +3018,8 @@
     "params": []
    },
    "inFREE": "1",
-   "setVALUE_LOW": 1,
    "setHASH_LEFT": 1,
-   "line": 15,
+   "line": 29,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
@@ -3010,9 +3029,8 @@
     "params": []
    },
    "inFREE": "1",
-   "setVALUE_HIGH": 1,
    "setHASH_RIGHT": 1,
-   "line": 16,
+   "line": 30,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
@@ -3024,7 +3042,7 @@
    "setHASH_RIGHT": 1,
    "iHash": "1",
    "iHashType": 0,
-   "line": 17,
+   "line": 31,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
@@ -3034,14 +3052,8 @@
     "params": []
    },
    "inFREE": "1",
-   "setSIBLING_RKEY": 1,
-   "line": 20,
-   "fileName": "storage_sm_set_zero_to_zero.zkasm"
-  },
-  {
-   "inSIBLING_RKEY": "1",
    "setHASH_LEFT": 1,
-   "line": 21,
+   "line": 34,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
@@ -3052,26 +3064,22 @@
    "setOLD_ROOT": 1,
    "iHash": "1",
    "iHashType": 1,
-   "line": 22,
+   "line": 35,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
    "inOLD_ROOT": "1",
    "setNEW_ROOT": 1,
-   "line": 25,
-   "fileName": "storage_sm_set_zero_to_zero.zkasm"
-  },
-  {
-   "CONST": "0",
-   "setVALUE_LOW": 1,
-   "setVALUE_HIGH": 1,
-   "line": 28,
+   "iJmp": "1",
+   "addressLabel": "SZTZ_InitLevel",
+   "line": 38,
+   "address": 361,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
    "CONST": "1",
    "setLEVEL": 1,
-   "line": 34,
+   "line": 50,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
@@ -3088,23 +3096,23 @@
    "inFREE": "1",
    "iJmpz": "1",
    "addressLabel": "SZTZ_LevelBit1",
-   "line": 37,
+   "line": 51,
    "address": 366,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
    "iRotateLevel": "1",
-   "line": 38,
+   "line": 52,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
    "iRotateLevel": "1",
-   "line": 39,
+   "line": 53,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
    "iRotateLevel": "1",
-   "line": 40,
+   "line": 54,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
@@ -3121,18 +3129,18 @@
    "inFREE": "1",
    "iJmpz": "1",
    "addressLabel": "SZTZ_ClimbTree",
-   "line": 45,
+   "line": 59,
    "address": 369,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
    "iRotateLevel": "1",
-   "line": 46,
+   "line": 60,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
    "iRotateLevel": "1",
-   "line": 47,
+   "line": 61,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
@@ -3144,7 +3152,7 @@
    "inFREE": "1",
    "iJmpz": "1",
    "addressLabel": "SZTZ_Latch",
-   "line": 52,
+   "line": 66,
    "address": 387,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
@@ -3158,7 +3166,7 @@
    "setRKEY_BIT": 1,
    "iJmpz": "1",
    "addressLabel": "SZTZ_SiblingIsRight",
-   "line": 55,
+   "line": 69,
    "address": 379,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
@@ -3170,13 +3178,13 @@
    },
    "inFREE": "1",
    "setHASH_LEFT": 1,
-   "line": 60,
+   "line": 74,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
    "inNEW_ROOT": "1",
    "setHASH_RIGHT": 1,
-   "line": 61,
+   "line": 75,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
@@ -3187,13 +3195,13 @@
    "setNEW_ROOT": 1,
    "iHash": "1",
    "iHashType": 0,
-   "line": 62,
+   "line": 76,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
    "inOLD_ROOT": "1",
    "setHASH_RIGHT": 1,
-   "line": 65,
+   "line": 79,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
@@ -3204,30 +3212,30 @@
    "setOLD_ROOT": 1,
    "iHash": "1",
    "iHashType": 0,
-   "line": 66,
+   "line": 80,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
    "iRotateLevel": "1",
-   "line": 69,
+   "line": 83,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
    "iClimbRkey": "1",
-   "line": 70,
+   "line": 84,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
    "iJmp": "1",
    "addressLabel": "SZTZ_ClimbTree",
-   "line": 72,
+   "line": 86,
    "address": 369,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
    "inNEW_ROOT": "1",
    "setHASH_LEFT": 1,
-   "line": 77,
+   "line": 91,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
@@ -3238,7 +3246,7 @@
    },
    "inFREE": "1",
    "setHASH_RIGHT": 1,
-   "line": 78,
+   "line": 92,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
@@ -3249,13 +3257,13 @@
    "setNEW_ROOT": 1,
    "iHash": "1",
    "iHashType": 0,
-   "line": 79,
+   "line": 93,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
    "inOLD_ROOT": "1",
    "setHASH_LEFT": 1,
-   "line": 82,
+   "line": 96,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
@@ -3266,35 +3274,35 @@
    "setOLD_ROOT": 1,
    "iHash": "1",
    "iHashType": 0,
-   "line": 83,
+   "line": 97,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
    "iRotateLevel": "1",
-   "line": 86,
+   "line": 100,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
    "iClimbRkey": "1",
-   "line": 87,
+   "line": 101,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
    "iJmp": "1",
    "addressLabel": "SZTZ_ClimbTree",
-   "line": 89,
+   "line": 103,
    "address": 369,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
    "iLatchSet": "1",
-   "line": 94,
+   "line": 108,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
   {
    "iJmp": "1",
    "addressLabel": "Run",
-   "line": 97,
+   "line": 111,
    "address": 0,
    "fileName": "storage_sm_set_zero_to_zero.zkasm"
   },
@@ -3419,6 +3427,8 @@
   "SDNF_SiblingIsRight3": 342,
   "SDNF_Latch": 350,
   "Set_ZeroToZero": 352,
+  "SZTZ_IsLeafNode": 355,
+  "SZTZ_IsIntermediateNode": 361,
   "SZTZ_InitLevel": 361,
   "SZTZ_LevelBit1": 366,
   "SZTZ_ClimbTree": 369,

--- a/zkasm/storage_sm_set_zero_to_zero.zkasm
+++ b/zkasm/storage_sm_set_zero_to_zero.zkasm
@@ -3,37 +3,51 @@ Set_ZeroToZero:
     ; Since we are setting a zero in a key that already had a zero,
     ; we initialize roots at zero and climb the tree up to the top
 
+    ; Case 1: Adding a zero having an Intermediate node as sibling
     ;  Root Node             Root Node (same as before)              # end of tree
     ;   / \                   / \                                    |
     ;     Intermediate Node      Intermediate Node (same as before)  ^ climb tree
     ;      / \                     / \                               |
     ; Sibling 0        ---> Sibling   0 (same as before)             * start here
 
-    ${GetRkey()} => RKEY
+    ; Case 2: Adding a zero having a leaf node as sibling
+    ;  Root Node             Root Node (same as before)              # end of tree
+    ;   / \                   / \                                    |
+    ;     Intermediate Node      Intermediate Node (same as before)  ^ climb tree
+    ;      / \                     / \                               |
+    ; Sibling Sibling  ---> Sibling   Sibling                        |
+    ;                                    \                           |
+    ;                                     0 (same as before)         * start here
 
+    ${GetRkey()} => RKEY                
+    
+    ${GetIsOld0()}                  :JMPZ(SZTZ_IsLeafNode)
+                                    :JMP(SZTZ_IsIntermediateNode)
+
+ SZTZ_IsLeafNode:                                   
     ; OldValueHash = Hash0( SIBLING_VALUE_LOW, SIBLING_VALUE_HIGH )
-    ${GetSiblingValueLow()} => VALUE_LOW, HASH_LEFT
-    ${GetSiblingValueHigh()} => VALUE_HIGH, HASH_RIGHT
+    ${GetSiblingValueLow()} => HASH_LEFT
+    ${GetSiblingValueHigh()} => HASH_RIGHT
     $ => SIBLING_VALUE_HASH, HASH_RIGHT :HASH0
 
     ; OldRoot = LeafNodeHash = Hash1( RKEY, Hash0( SIBLING_VALUE_LOW, SIBLING_VALUE_HIGH ) )
-    ${GetSiblingRkey()} => SIBLING_RKEY
-    SIBLING_RKEY => HASH_LEFT
+    ${GetSiblingRkey()} => HASH_LEFT
     $ => OLD_ROOT                   :HASH1
 
     ; NewRoot = OldRoot
-    OLD_ROOT => NEW_ROOT
+    OLD_ROOT => NEW_ROOT            :JMP(SZTZ_InitLevel)
 
-    ; Forced to zero, because we are setting to zero.
-    0 => VALUE_LOW, VALUE_HIGH
+    ; VALUE_LOW, VALUE_HIGH are zero (initialized to 0 in storage_sm.zkasm)
+
+SZTZ_IsIntermediateNode:
+    ; VALUE_LOW, VALUE_HIGH are zero (initialized to 0 in storage_sm.zkasm)
+    ; OLD_ROOT, NEW_ROOT are zero (initialized to 0 in storage_sm.zkasm)
 
 SZTZ_InitLevel:
-
-    ; Init LEVEL register to {1,0,0,0}, and inversely rotate it level%4 times,
+    ; Init LEVEL register is set to {1,0,0,0}, and inversely rotate it level%4 times,
     ; so that after level rotations the position of LEVEL becomes {1,0,0,0} again
-    0x1 => LEVEL
-
     ; If level bit 0 is 1, then do 1 inverse rotation (i.e. 3 normal rotations)
+    0x1 => LEVEL    
     ${GetLevelBit(0)}               :JMPZ(SZTZ_LevelBit1)
                                     :ROTATE_LEVEL
                                     :ROTATE_LEVEL


### PR DESCRIPTION
Fixed the folllowing zeroTozero cases:
1. Inserting a zero in an empty tree.
2. Inserting a zero having an intermediate node as sibling